### PR TITLE
Give the Cooper Hewitt solid-colored walls.

### DIFF
--- a/assets/Cooper_Hewitt/import_cooper_hewitt.gd
+++ b/assets/Cooper_Hewitt/import_cooper_hewitt.gd
@@ -10,4 +10,16 @@ func post_import(scene):
                 print("Modifying material for " + node.name + " to be less shiny.")
                 material.params_diffuse_mode = SpatialMaterial.DIFFUSE_TOON
                 material.params_specular_mode = SpatialMaterial.SPECULAR_DISABLED
+                var tex = material.get_texture(SpatialMaterial.TEXTURE_ALBEDO)
+                if tex:
+                    var size = tex.get_size()
+                    var image = tex.get_data()
+                    image.decompress()
+                    image.lock()
+                    var color = image.get_pixel(size.x / 2, size.y / 2)
+                    image.unlock()
+                    print("Center is color " + str(color))
+                    material.set_texture(SpatialMaterial.TEXTURE_ALBEDO, null)
+                    material.albedo_color = color
+                    print("Albedo color is now " + str(material.albedo_color) + ".")
     return scene


### PR DESCRIPTION
This gives the mansion solid-colored walls based on the color of the center pixel on each mesh's texture.  I'm not really sure how well it works, though.

Also, the importer appears to use the existing `.material` files for each material from its last import, which means you basically have to remove the material files in order to run the import script again if it's changed, which is weird.