### PR TITLE
Use multi-threaded HTML5 builds w/ Godot 3.2.4rc3.

### DIFF
--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -8,15 +8,16 @@ export_filter="all_resources"
 include_filter=""
 exclude_filter=""
 export_path="dist/index.html"
-patch_list=PoolStringArray(  )
 script_export_mode=1
 script_encryption_key=""
 
 [preset.0.options]
 
+custom_template/debug=""
+custom_template/release=""
+variant/export_type=1
 vram_texture_compression/for_desktop=true
 vram_texture_compression/for_mobile=false
 html/custom_html_shell=""
 html/head_include=""
-custom_template/release=""
-custom_template/debug=""
+html/canvas_resize_policy=2


### PR DESCRIPTION
This attempts to enable HTML5 multi-threaded builds using Godot 3.2.4rc3, which appears to add threaded support for audio, which I thought might be helpful since the music seems to be stuttering on Chrome.  While it does appear to fix the audio stuttering on Chrome, it also raises `SharedArrayBuffer is not defined` on Firefox, and according to [this thread](https://www.godotforums.org/discussion/25647/html5-build-not-running-on-mozilla-firefox-browser-on-windows-10) it soon won't work on Chrome unless we [enable cross-origin isolation](https://developer.chrome.com/blog/enabling-shared-array-buffer/), which I'm not sure GitHub pages even supports.  Doh.